### PR TITLE
views.py: Fix bad model name

### DIFF
--- a/artworks/views.py
+++ b/artworks/views.py
@@ -130,7 +130,7 @@ class ArtUpdateView(generic.UpdateView):
 		 	if old_id in new_ids:
 		 		continue
 		 	else:
-		 		ArtworkObject.objects \
+		 		ArtworkSubject.objects \
 		 			.filter(artwork_id=art.artwork_id, subject_id=old_id) \
 		 			.delete()
 


### PR DESCRIPTION
Object not found error thrown when updating an existing list of subjects.

class ArtUpdateView(generic.UpdateView)

Model is `ArtworkSubject` not `ArtworkObject`
